### PR TITLE
Change descriptions on characters

### DIFF
--- a/advanced-iterators.html
+++ b/advanced-iterators.html
@@ -435,8 +435,8 @@ for guess in itertools.permutations(digits, len(characters)):
 <a><samp class=p>>>> </samp><kbd class=pp>'MARK'.translate(translation_table)</kbd>       <span class=u>&#x2462;</span></a>
 <samp class=pp>'MORK'</samp></pre>
 <ol>
-<li>String translation starts with a translation table, which is just a dictionary that maps one character to another. Actually, &#8220;character&#8221; is incorrect&nbsp;&mdash;&nbsp;the translation table really maps one <em>byte</em> to another.
-<li>Remember, bytes in Python 3 are integers. The <code>ord()</code> function returns the <abbr>ASCII</abbr> value of a character, which, in the case of A&ndash;Z, is always a byte from 65 to 90.
+<li>String translation starts with a translation table, which is just a dictionary that maps one character to another.
+<li>Remember, characters in Python 3 are integers. The <code>ord()</code> function returns the <abbr>Unicode decimal</abbr> value of a character, which, in the case of A&ndash;Z, is always a decimal from 65 to 90.
 <li>The <code>translate()</code> method on a string takes a translation table and runs the string through it. That is, it replaces all occurrences of the keys of the translation table with the corresponding values. In this case, &#8220;translating&#8221; <code>MARK</code> to <code>MORK</code>.
 </ol>
 


### PR DESCRIPTION
A Unicode character is not always a byte, especially in the case of CJK characters.

For example:
```
>>> translation_table = {ord('가'): ord('겨')}
>>> translation_table
{44032: 44200}
```
